### PR TITLE
Add benchmark comparison for slice optimizations

### DIFF
--- a/jsonpatch/benchmark_test.go
+++ b/jsonpatch/benchmark_test.go
@@ -1,0 +1,25 @@
+package jsonpatch
+
+import "testing"
+
+func BenchmarkApplyRealistic(b *testing.B) {
+	patch := []map[string]any{
+		{"op": "str_ins", "path": "/text", "pos": 3, "str": "def"},
+		{"op": "inc", "path": "/counter", "inc": 5},
+		{"op": "replace", "path": "/nested/value", "value": "updated"},
+		{"op": "add", "path": "/arr/0", "value": 1},
+		{"op": "remove", "path": "/arr/0"},
+	}
+
+	for i := 0; i < b.N; i++ {
+		doc := map[string]any{
+			"text":    "abc",
+			"counter": 0,
+			"nested":  map[string]any{"value": "original"},
+			"arr":     []any{},
+		}
+		if err := Apply(doc, patch); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}

--- a/jsonpatch/jsonpatch.go
+++ b/jsonpatch/jsonpatch.go
@@ -212,13 +212,13 @@ func Apply(doc map[string]any, operations []map[string]any) error {
 				if finalIndex < 0 || finalIndex > len(targetSlice) {
 					return fmt.Errorf("index %d out of bounds for %q op at path %q (slice len %d)", finalIndex, "add", pathRaw, len(targetSlice))
 				}
-				newSlice := append(targetSlice, nil)
-				copy(newSlice[finalIndex+1:], targetSlice[finalIndex:])
-				newSlice[finalIndex] = value
+				targetSlice = append(targetSlice, nil)
+				copy(targetSlice[finalIndex+1:], targetSlice[finalIndex:])
+				targetSlice[finalIndex] = value
 				if parentMap, ok := containerParent.(map[string]any); ok {
-					parentMap[containerParentKey] = newSlice
+					parentMap[containerParentKey] = targetSlice
 				} else if parentSlice, ok := containerParent.([]any); ok {
-					parentSlice[containerParentIndex] = newSlice
+					parentSlice[containerParentIndex] = targetSlice
 				} else {
 					return fmt.Errorf("internal error: cannot assign updated slice for op %q", "add")
 				}
@@ -236,11 +236,12 @@ func Apply(doc map[string]any, operations []map[string]any) error {
 				if finalIndex < 0 || finalIndex >= len(targetSlice) {
 					return fmt.Errorf("index %d out of bounds for %q op at path %q (slice len %d)", finalIndex, "remove", pathRaw, len(targetSlice))
 				}
-				newSlice := append(targetSlice[:finalIndex], targetSlice[finalIndex+1:]...)
+				copy(targetSlice[finalIndex:], targetSlice[finalIndex+1:])
+				targetSlice = targetSlice[:len(targetSlice)-1]
 				if parentMap, ok := containerParent.(map[string]any); ok {
-					parentMap[containerParentKey] = newSlice
+					parentMap[containerParentKey] = targetSlice
 				} else if parentSlice, ok := containerParent.([]any); ok {
-					parentSlice[containerParentIndex] = newSlice
+					parentSlice[containerParentIndex] = targetSlice
 				} else {
 					return fmt.Errorf("internal error: cannot assign updated slice for op %q", "remove")
 				}


### PR DESCRIPTION
## Summary
- optimize slice handling for `add` and `remove` operations
- benchmark `BenchmarkApplyRealistic` before and after optimization

## Testing
- `go test ./...`
- `go test -bench BenchmarkApplyRealistic -benchmem ./jsonpatch`